### PR TITLE
グループの一覧を取得するエンドポイントの追加

### DIFF
--- a/swagger/openapi.yaml
+++ b/swagger/openapi.yaml
@@ -29,32 +29,10 @@ paths:
       description: 記事の一覧を作成日時の降順で返します。
       operationId: searchEvents
       parameters:
-        - name: fields
-          in: query
-          description: 検索結果で取得するフィールドをカンマ区切りで指定
-          required: false
-          schema:
-            type: string
-        - name: query
-          in: query
-          description: 検索クエリ
-          required: false
-          schema:
-            type: string
-        - name: page
-          in: query
-          description: 'ページ番号 (1から100まで)'
-          required: false
-          schema:
-            type: integer
-            format: int64
-        - name: perPage
-          in: query
-          description: '1ページあたりに含まれる要素数 (1から100まで)'
-          required: false
-          schema:
-            type: integer
-            format: int64
+        - $ref: '#/components/parameters/Fields'
+        - $ref: '#/components/parameters/Query'
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/PerPage'
       responses:
         200:
           $ref: '#/components/responses/Events'
@@ -447,6 +425,37 @@ paths:
       security:
         - ApiKeyAuth: []
 components:
+  parameters:
+    Fields:
+      name: fields
+      in: query
+      description: 検索結果で取得するフィールドをカンマ区切りで指定
+      required: false
+      schema:
+        type: string
+    Query:
+      name: query
+      in: query
+      description: 検索クエリ
+      required: false
+      schema:
+        type: string
+    Page:
+      name: page
+      in: query
+      description: 'ページ番号 (1から100まで)'
+      required: false
+      schema:
+        type: integer
+        format: int64
+    PerPage:
+      name: perPage
+      in: query
+      description: '1ページあたりに含まれる要素数 (1から100まで)'
+      required: false
+      schema:
+        type: integer
+        format: int64
   requestBodies:
     Event:
       description: 追加するためにはEventオブジェクトが必要です

--- a/swagger/openapi.yaml
+++ b/swagger/openapi.yaml
@@ -252,6 +252,23 @@ paths:
           description: No Content
       security:
         - ApiKeyAuth: []
+  /groups:
+    get:
+      tags:
+        - group
+      summary: グループを検索する
+      description: グループの一覧を作成日時の降順で返します。
+      operationId: searchGroups
+      parameters:
+        - $ref: '#/components/parameters/Fields'
+        - $ref: '#/components/parameters/Query'
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/PerPage'
+      responses:
+        200:
+          $ref: '#/components/responses/Groups'
+      security:
+        - ApiKeyAuth: []
   /group:
     post:
       tags:
@@ -493,7 +510,7 @@ components:
           schema:
             $ref: '#/components/schemas/Event'
     Events:
-      description: OK
+      description: イベント検索後のイベントの一覧を返します
       content:
         application/json:
           schema:
@@ -512,13 +529,20 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/User'
-
     Group:
       description: 追加または更新されたGroupオブジェクトを返します
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/Group'
+    Groups:
+      description: グループ検索後のグループの一覧を返します
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/Group'
     Entry:
       description: 参加したUserオブジェクトの配列を返します
       content:


### PR DESCRIPTION
## やったこと
 - グループ検索を行うためのエンドポイントを作成
   - Home画面で、最近作成されたグループを表示する必要があったため、追加でエンドポイント作成
 - 検索条件となるfields, query, page, perPageをcomponentに切り出し

## ちょっと気になったこと
 - 検索条件となるpage, perPageの命名が少し直感的ではない？
   - 個人的にはoffset, limitの方がクエリらしくて好き。でも好き好きかなとも思った。意見求む。

## 確認事項
```
swagger UI上で確認。文字少ない方がよかったからこれにしたが、curlでも確認できる。
```
 - /eventsからTry it out > ExecuteでApiを実行
   - Schemas > Event内の定義情報をみて、APIのresponseに抜け漏れがないこと
 - /groupsからTry it out > ExecuteでApiを実行
   - Schemas > Group内の定義情報をみて、APIのresponseに抜け漏れがないこと