### PR TITLE
group idからevent群を取得するendpointの作成

### DIFF
--- a/swagger/openapi.yaml
+++ b/swagger/openapi.yaml
@@ -309,7 +309,7 @@ paths:
         - group
       summary: グループ情報内イベント群を取得する
       description: 'Returns a single group'
-      operationId: 'getGroupEventsById'
+      operationId: searchGroupEventsById
       parameters:
         - name: groupId
           in: path

--- a/swagger/openapi.yaml
+++ b/swagger/openapi.yaml
@@ -303,6 +303,26 @@ paths:
           $ref: '#/components/responses/Group'
       security:
         - ApiKeyAuth: []
+  /group/{groupId}/events:
+    get:
+      tags:
+        - group
+      summary: グループ情報内イベント群を取得する
+      description: 'Returns a single group'
+      operationId: 'getGroupEventsById'
+      parameters:
+        - name: groupId
+          in: path
+          description: 'ID of group to return'
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        200:
+          $ref: '#/components/responses/Events'
+      security:
+        - ApiKeyAuth: []
   /group/{groupId}/member:
     post:
       tags:


### PR DESCRIPTION
## やったこと

group idからevent群を取得するendpointの作成

## 確認すること

 - 以下コマンドを実行
   - `curl -X GET "http://127.0.0.1:8083/group/0/events" -H "accept: application/json"`

以下結果が取得できること
```json
[
  {
    "capacity": 10,
    "categories": [
      {
        "id": 0,
        "name": "Gophar"
      }
    ],
    "colorCode": "#f0f8ff",
    "description": "エンジニア集まれ",
    "entries": [
      {
        "id": 0,
        "name": "Hogehoge Taro"
      }
    ],
    "group": {
      "colorCode": "#6495ed",
      "description": "月一で勉強会をするよ",
      "domain": "dev-meeting",
      "id": 0,
      "imagePath": "https://miro.medium.com/max/1200/1*aKVg84SP5oPV9fwOnbl6yQ.png",
      "name": "開発部勉強会"
    },
    "holdEndDate": "2019/07/19 19:00:00",
    "holdStartDate": "2019/07/19 16:30:00",
    "id": 0,
    "imageUrl": "https://miro.medium.com/max/1200/1*aKVg84SP5oPV9fwOnbl6yQ.png",
    "organizer": [
      {
        "id": 0,
        "name": "Hogehoge Taro"
      }
    ],
    "qrCodeUrl": "https://miro.medium.com/max/1200/1*aKVg84SP5oPV9fwOnbl6yQ.png",
    "recruitEndDate": "2019/07/16 24:00:00",
    "recruitStartDate": "2019/07/01 24:00:00",
    "title": "合同勉強会",
    "venue": {
      "id": 0,
      "name": "Village"
    }
  }
]
```

## 気になること

正直groupの取得はいらない。ただswaggerのcomponentの分け方の都合上入ってしまう。
この辺りは実装時に入れなくてもいいので、実際のresponseに含めなくてもいいかも。
実際にはcomponentを分割した方がいいのだろうが、MUSTではないので対応はスキップ。