### PR TITLE
イベント参加エンドポイントのrequestBodyの変更

### DIFF
--- a/swagger/openapi.yaml
+++ b/swagger/openapi.yaml
@@ -185,15 +185,7 @@ paths:
             type: integer
             format: int64
       requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                entries:
-                  type: array
-                  items:
-                    $ref: '#/components/schemas/Entry'
+        $ref: '#/components/requestBodies/Entry'
       responses:
         200:
           $ref: '#/components/responses/Entry'
@@ -474,6 +466,13 @@ components:
         type: integer
         format: int64
   requestBodies:
+    Entry:
+      description: 追加するためにはUserオブジェクトの配列が必要です
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Entry'
     Event:
       description: 追加するためにはEventオブジェクトが必要です
       required: true
@@ -561,6 +560,10 @@ components:
                 type: array
                 items:
                   $ref: '#/components/schemas/User'
+              organizer:
+                type: array
+                items:
+                  $ref: '#/components/schemas/User'
   securitySchemes:
     ApiKeyAuth:
       type: apiKey
@@ -570,15 +573,14 @@ components:
     Entry:
       type: object
       properties:
-        id:
-          type: integer
-          format: int64
-        name:
-          type: string
-          example: 'Hogehoge Taro'
-        role:
-          type: string
-          example: 'Basic User'
+        entries:
+          type: array
+          items:
+            $ref: '#/components/schemas/User'
+        organizer:
+          type: array
+          items:
+            $ref: '#/components/schemas/User'
     Group:
       type: object
       properties:

--- a/swagger/openapi.yaml
+++ b/swagger/openapi.yaml
@@ -513,14 +513,7 @@ components:
       content:
         application/json:
           schema:
-            type: object
-            properties:
-              uid:
-                type: string
-                example: 'ac85b9f0d13726934e236548ed6b95184d2603a2'
-              name:
-                type: string
-                example: 'Hogehoge Taro'
+            $ref: '#/components/schemas/User'
     Group:
       description: 追加するためにはGroupオブジェクトが必要です
       required: true

--- a/swagger/openapi.yaml
+++ b/swagger/openapi.yaml
@@ -580,7 +580,7 @@ components:
                 type: array
                 items:
                   $ref: '#/components/schemas/User'
-              organizer:
+              organizers:
                 type: array
                 items:
                   $ref: '#/components/schemas/User'
@@ -597,7 +597,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/User'
-        organizer:
+        organizers:
           type: array
           items:
             $ref: '#/components/schemas/User'
@@ -682,7 +682,7 @@ components:
           type: string
           format: date-time
           example: '2019/07/16 24:00:00'
-        organizer:
+        organizers:
           type: array
           items:
             $ref: '#/components/schemas/User'

--- a/swagger/openapi.yaml
+++ b/swagger/openapi.yaml
@@ -106,7 +106,7 @@ paths:
                   type: string
                 capacity:
                   description: Updated capacity of the event
-                  type: string
+                  type: integer
                 imageUrl:
                   type: string
                   description: イベントの画像
@@ -655,8 +655,8 @@ components:
           type: string
           example: エンジニア集まれ
         capacity:
-          type: string
-          example: '50'
+          type: integer
+          example: 50
         colorCode:
           type: string
           example: '#f0f8ff'

--- a/swagger/openapi.yaml
+++ b/swagger/openapi.yaml
@@ -620,9 +620,6 @@ components:
         name:
           type: string
           example: 'Hogehoge Taro'
-        uid:
-          type: string
-          example: 'ac85b9f0d13726934e236548ed6b95184d2603a2'
     Event:
       type: object
       required:

--- a/swagger/openapi.yaml
+++ b/swagger/openapi.yaml
@@ -497,8 +497,7 @@ components:
             type: object
             properties:
               uid:
-                type: integer
-                format: int64
+                type: string
                 example: 'ac85b9f0d13726934e236548ed6b95184d2603a2'
               name:
                 type: string
@@ -584,8 +583,8 @@ components:
       type: object
       properties:
         id:
-          type: integer
-          format: int64
+          type: string
+          example: '1'
         name:
           type: string
           example: '開発部勉強会'
@@ -605,8 +604,8 @@ components:
       type: object
       properties:
         id:
-          type: integer
-          format: int64
+          type: string
+          example: '1'
         name:
           type: string
           example: 'Gophar'
@@ -614,14 +613,13 @@ components:
       type: object
       properties:
         id:
-          type: integer
-          format: int64
+          type: string
+          example: '1'
         name:
           type: string
           example: 'Hogehoge Taro'
         uid:
-          type: integer
-          format: int64
+          type: string
           example: 'ac85b9f0d13726934e236548ed6b95184d2603a2'
     Event:
       type: object
@@ -629,8 +627,8 @@ components:
         - title
       properties:
         id:
-          type: integer
-          format: int64
+          type: string
+          example: '1'
         title:
           type: string
           example: 合同勉強会
@@ -638,9 +636,8 @@ components:
           type: string
           example: エンジニア集まれ
         capacity:
-          type: integer
-          format: int64
-          example: 10
+          type: string
+          example: '50'
         colorCode:
           type: string
           example: '#f0f8ff'
@@ -688,8 +685,8 @@ components:
         - name
       properties:
         id:
-          type: integer
-          format: int64
+          type: string
+          example: '1'
         name:
           type: string
           example: 'Village'


### PR DESCRIPTION
# やったこと
- entryEventのrequestBodyの形式を変更
- オブジェクトのidの値をintegerからstringに変更
- responseにuidが含まれないように修正

# 気になること
- idがstringのにしたけどほんとに良きかどうか。
- frontendにも影響があると思いますので確認お願いします。