### PR TITLE
主催者のカラムを複数形に変更

### DIFF
--- a/swagger/openapi.yaml
+++ b/swagger/openapi.yaml
@@ -671,7 +671,7 @@ components:
           type: string
           format: date-time
           example: '2019/07/16 24:00:00'
-        organizer:
+        organizers:
           type: array
           items:
             $ref: '#/components/schemas/User'


### PR DESCRIPTION
## やったこと

event内の主催者のカラムを単数形から複数形に命名を変更

## 確認事項

コンテナを再起動し、以下コマンドを実行

```sh
curl -X GET "http://127.0.0.1:8083/event/0" -H "accept: application/json" | jq 'keys' | grep organizers | wc -l
```

1が表示されること