### PR TITLE
ユーザーの追加時のschemaを分割

### DIFF
--- a/swagger/openapi.yaml
+++ b/swagger/openapi.yaml
@@ -514,15 +514,7 @@ components:
       content:
         application/json:
           schema:
-            type: object
-            properties:
-              uid:
-                type: integer
-                format: int64
-                example: 'ac85b9f0d13726934e236548ed6b95184d2603a2'
-              name:
-                type: string
-                example: 'Hogehoge Taro'
+            $ref: '#/components/schemas/AddUser'
     Group:
       description: 追加するためにはGroupオブジェクトが必要です
       required: true
@@ -640,8 +632,16 @@ components:
           type: string
           example: 'Hogehoge Taro'
         uid:
-          type: integer
-          format: int64
+          type: string
+          example: 'ac85b9f0d13726934e236548ed6b95184d2603a2'
+    AddUser:
+      type: object
+      properties:
+        name:
+          type: string
+          example: 'Hogehoge Taro'
+        uid:
+          type: string
           example: 'ac85b9f0d13726934e236548ed6b95184d2603a2'
     Event:
       type: object


### PR DESCRIPTION
## やったこと

swaggerの定義のうち、componentsのユーザー追加の箇所がfrontend側でのclient自動生成時にエラーで作成できないエラーが発生していたため修正。

## 確認事項

connthass/frontendでyarn apiを実行し、実行が成功すること