### PR TITLE
必要component群を追加

### DIFF
--- a/swagger/openapi/components/responses.yaml
+++ b/swagger/openapi/components/responses.yaml
@@ -7,7 +7,14 @@ Event:
       examples:
         EventResponse:
           $ref: "#/components/examples/EventResponse"
-
+Events:
+  description: イベント検索後のイベントの一覧を返します
+  content:
+    application/json:
+      schema:
+        type: array
+        items:
+          $ref: "#/components/schemas/Event"
 AddEvent:
   description: 追加されたEventオブジェクトを返します
   content:

--- a/swagger/openapi/components/schemas.yaml
+++ b/swagger/openapi/components/schemas.yaml
@@ -168,7 +168,21 @@ UpdateEvent:
       $ref: "#/components/schemas/Group"
     venue:
       $ref: "#/components/schemas/Venue"
-
+Entry:
+  description: 参加したUserオブジェクトの配列を返します
+  content:
+    application/json:
+      schema:
+        type: object
+        properties:
+          entries:
+            type: array
+            items:
+              $ref: "#/components/schemas/User"
+          organizers:
+            type: array
+            items:
+              $ref: "#/components/schemas/User"
 Venue:
   type: object
   required:


### PR DESCRIPTION

api-docsで画面を表示時に画面表示でエラーが発生した。

```
2019/10/06 10:14:29 Failed to resolve 'Entry' in fragment in URI: '#/components/schemas/Entry'
2019/10/06 10:17:26 Failed to resolve 'Events' in fragment in URI: '#/components/responses/Events'
```

必要なcomponentが入力されていないことによるエラーが発生。
そのため、必要component群の追加を行う。

## 検証

```
検証する前にapi-docs群のcontainerの立ち上げを行った上で検証を実施
```

 - http://localhost:3000/を開く
   - 以下画面が表示されること

![FireShot Capture 032 - React App - localhost](https://user-images.githubusercontent.com/32930281/66267759-16eb2080-e870-11e9-96f7-a4b6d9089fd4.png)
